### PR TITLE
fix: Remove excessive logging from EmployeeDashboard

### DIFF
--- a/src/components/EmployeeDashboard.jsx
+++ b/src/components/EmployeeDashboard.jsx
@@ -139,18 +139,6 @@ const EmployeeDashboard = ({ currentUser, onLogout }) => {
     return () => clearInterval(interval);
   }, [calculatePendingCounts]);
 
-  // Also update counts when cache data changes (immediate updates)
-  useEffect(() => {
-    const updateCounts = () => {
-      const newCounts = calculatePendingCounts();
-      setPendingCounts(newCounts);
-    };
-
-    // Listen for cache updates
-    const checkInterval = setInterval(updateCounts, 10000); // Check every 10 seconds for immediate updates
-
-    return () => clearInterval(checkInterval);
-  }, [calculatePendingCounts]);
 
   // Setup new task notifications
   useEffect(() => {


### PR DESCRIPTION
Removes the 10-second interval that was causing excessive "Cache hit" log messages. The existing 2-minute interval is sufficient for updating the pending counts.